### PR TITLE
Tag-based release: PRs validate locally, tag push pushes to GAR

### DIFF
--- a/.github/workflows/build-push-create-pr.yaml
+++ b/.github/workflows/build-push-create-pr.yaml
@@ -2,14 +2,8 @@ name: Build and push container image, and update edx-hub repo if needed
 on:
   workflow_dispatch:
   push:
-    branches:
-      - main
-    paths-ignore:
-      - 'README.md'
-      - 'CONTRIBUTING.md'
-      - 'LICENSE'
-      - '.github/**'
-      - 'images/**'
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   build-and-push:
@@ -51,6 +45,15 @@ jobs:
 
       - name: Show how much disk space is left
         run: df -h
+
+      - name: Notify Slack
+        if: always()
+        uses: slackapi/slack-github-action@v1
+        with:
+          payload: |
+            {"text": "${{ job.status == 'success' && '✅' || '❌' }} edx-user-image release ${{ job.status }} — tag `${{ github.ref_name }}` → image `${{ steps.build-and-push.outputs.IMAGE_SHA_TAG }}` · <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Run #${{ github.run_id }}>"}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   update-deployment-image-tag:
     runs-on: ubuntu-latest

--- a/.github/workflows/grader-check.yml
+++ b/.github/workflows/grader-check.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           FORCE_REPO2DOCKER_VERSION: jupyter-repo2docker==2024.07.0
           IMAGE_NAME: edx-user-image
+          NO_PUSH: true
           LATEST_TAG_OFF: false
           REPO_DIR: /srv/repo
 


### PR DESCRIPTION
## Summary

Aligns this repo's release flow with `otter-service`: PRs build and test the image locally on the runner; pushing an `X.Y.Z` tag triggers the actual GAR push.

- **`grader-check.yml`**: add `NO_PUSH: true` to the `Build PR image` step. The PR job has no GAR credentials, so the previous configuration was failing with `denied: requested access to the resource is denied` and skipping all downstream test steps. With `NO_PUSH: true`, the image is still tagged `edx-user-image:latest` on the runner, so `Run grader.check tests` continues to find it.
- **`build-push-create-pr.yaml`**: change trigger from every push to `main` (with `paths-ignore`) to push of a semver tag matching `[0-9]+.[0-9]+.[0-9]+`. This matches `otter-service/.github/workflows/release.yml`'s pattern. `workflow_dispatch` is preserved for manual runs.
- **`build-push-create-pr.yaml`**: add a Slack notify step at the end of the `build-and-push` job that includes the tag and the resulting `IMAGE_SHA_TAG`, so the channel sees what shipped.

## Resulting flow

| Trigger | Workflow | Push to GAR? | Slack? |
|---|---|---|---|
| PR open/update | `grader-check.yml` | No | Yes (pass/fail) |
| PR open/update | `build-test-image.yaml` | No | (existing) |
| Tag `X.Y.Z` push | `build-push-create-pr.yaml` | Yes | Yes (with image SHA tag) |
| Manual dispatch | `build-push-create-pr.yaml` | Yes | Yes |

## Test plan

- [ ] PR check (this PR) — `Grader Check` reaches `Run grader.check tests` step (no longer skipped due to push failure)
- [ ] After merge, push a test tag (e.g. `0.0.1-test` won't match; need `X.Y.Z`) and confirm `build-push-create-pr.yaml` runs, pushes to GAR, and Slack notifies with the image SHA
- [ ] Confirm `update-deployment-image-tag` job still opens a PR against `edx-berkeley/edx-hub` after a real tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)