### PR TITLE
ci: switch grader-check to pull_request_target (fork PRs get secrets)

### DIFF
--- a/.github/workflows/grader-check.yml
+++ b/.github/workflows/grader-check.yml
@@ -1,7 +1,7 @@
 name: Grader Check
 
 on:
-  pull_request:
+  pull_request_target:
     paths-ignore:
       - 'README.md'
       - 'CONTRIBUTING.md'
@@ -15,6 +15,8 @@ jobs:
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Free up disk space
         run: |


### PR DESCRIPTION
## Summary

Smoke test PR #25 surfaced `RuntimeError: No GitHub credentials found` in the Fetch notebooks step. Root cause: GitHub does not pass repo secrets to `pull_request` workflows triggered from forks (security policy), so `OTTER_GH_APP_*` came up empty.

This switches the trigger to `pull_request_target`, which runs in the base-repo context with secret access. We explicitly check out the PR's head SHA so the rest of the workflow validates the proposed code rather than the base.

Mirrors `otter-service/.github/workflows/docker-grade-check.yml`.

## Caveat

`pull_request_target` exposes secrets to code running from the PR head. Safe given current PR authorship is restricted to org members. If untrusted PRs are ever expected, consider gating the Fetch notebooks step on PR author or moving the secrets-using portion to a dispatched workflow.

## Test plan

- [ ] After merge, reopen / push to PR #25 (smoke-test-grader-check) — Fetch notebooks should succeed and Run grader.check tests should run

🤖 Generated with [Claude Code](https://claude.com/claude-code)