### PR TITLE
ci: install pyjwt[crypto] for RS256 in Fetch notebooks

### DIFF
--- a/.github/workflows/grader-check.yml
+++ b/.github/workflows/grader-check.yml
@@ -38,7 +38,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install test script dependencies
-        run: pip install requests pyjwt nbformat pytz
+        run: pip install requests "pyjwt[crypto]" nbformat pytz
 
       - name: Fetch notebooks
         env:


### PR DESCRIPTION
## Summary
- Add `[crypto]` extra to pyjwt so RS256 signing of the GitHub App JWT works
- Smoke test PR #25 surfaced `NotImplementedError: Algorithm 'RS256' could not be found` after auth secrets started flowing