### PR TITLE
ci: also tag image with release version on tag push

### DIFF
--- a/.github/workflows/build-push-create-pr.yaml
+++ b/.github/workflows/build-push-create-pr.yaml
@@ -46,6 +46,14 @@ jobs:
       - name: Show how much disk space is left
         run: df -h
 
+      - name: Tag image with version
+        if: github.ref_type == 'tag'
+        run: |
+          SRC="us-central1-docker.pkg.dev/${IMAGE}:${{ steps.build-and-push.outputs.IMAGE_SHA_TAG }}"
+          DST="us-central1-docker.pkg.dev/${IMAGE}:${{ github.ref_name }}"
+          docker tag "$SRC" "$DST"
+          docker push "$DST"
+
       - name: Notify Slack
         if: always()
         uses: slackapi/slack-github-action@v1


### PR DESCRIPTION
## Summary

Currently, `repo2docker-action` tags pushed images with only the git short SHA (used by edx-hub deployments for immutable pinning — good). This adds a follow-up step that also tags and pushes `:<version>` (e.g. `:1.0.0`) when triggered by a tag push, so images can be referenced by semver in addition to SHA.

Deployments still pin to SHA (unchanged); the version tag is a human-friendly handle for rollbacks, debugging, ad-hoc pulls. Mirrors otter-service's cloudbuild dual-tag pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)