### PR TITLE
ci: rename private key secrets to match GitHub App names

### DIFF
--- a/.github/workflows/build-push-create-pr.yaml
+++ b/.github/workflows/build-push-create-pr.yaml
@@ -89,7 +89,7 @@ jobs:
         id: app-token
         with:
           app-id: ${{ vars.EDX_IMAGE_BUILDER_APP_ID }}
-          private-key: ${{ secrets.PRIVATE_KEY_SECRET }}
+          private-key: ${{ secrets.EDX_IMAGE_BUILDER_PRIVATE_KEY }}
           owner: edx-berkeley
 
       - name: Checkout the edx-hub repo

--- a/.github/workflows/grader-check.yml
+++ b/.github/workflows/grader-check.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Fetch notebooks
         env:
           GITHUB_APP_ID: ${{ vars.OTTER_AUTOGRADERS_APP_ID }}
-          GITHUB_APP_PRIVATE_KEY: ${{ secrets.OTTER_GH_APP_PRIVATE_KEY }}
+          GITHUB_APP_PRIVATE_KEY: ${{ secrets.OTTER_AUTOGRADERS_PRIVATE_KEY }}
           GITHUB_APP_INSTALLATION_ID: ${{ vars.OTTER_AUTOGRADERS_INSTALLATION_ID }}
         run: |
           python tests/fetch_test_notebooks.py --courses "88ex,88bx,88cx,8x"

--- a/.github/workflows/grader-check.yml
+++ b/.github/workflows/grader-check.yml
@@ -42,9 +42,9 @@ jobs:
 
       - name: Fetch notebooks
         env:
-          GITHUB_APP_ID: ${{ vars.OTTER_AUTOGRADERS_APP_ID }}
-          GITHUB_APP_PRIVATE_KEY: ${{ secrets.OTTER_AUTOGRADERS_PRIVATE_KEY }}
-          GITHUB_APP_INSTALLATION_ID: ${{ vars.OTTER_AUTOGRADERS_INSTALLATION_ID }}
+          GITHUB_APP_ID: ${{ vars.COURSE_CONTENT_READER_APP_ID }}
+          GITHUB_APP_PRIVATE_KEY: ${{ secrets.COURSE_CONTENT_READER_PRIVATE_KEY }}
+          GITHUB_APP_INSTALLATION_ID: ${{ vars.COURSE_CONTENT_READER_INSTALLATION_ID }}
         run: |
           python tests/fetch_test_notebooks.py --courses "88ex,88bx,88cx,8x"
 

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ The following must be configured on the repository (or the `edx-berkeley` organi
 | `EDX_IMAGE_BUILDER_APP_ID` | GitHub App ID used to open PRs in edx-hub |
 | `IMAGE_BUILDER_BOT_EMAIL` | Git author email for automated commits to edx-hub |
 | `IMAGE_BUILDER_BOT_NAME` | Git author name for automated commits to edx-hub |
-| `OTTER_AUTOGRADERS_APP_ID` | GitHub App ID for reading autograder repos |
-| `OTTER_AUTOGRADERS_INSTALLATION_ID` | Installation ID for the autograder GitHub App |
+| `COURSE_CONTENT_READER_APP_ID` | GitHub App ID for reading autograder/student/solution repos |
+| `COURSE_CONTENT_READER_INSTALLATION_ID` | Installation ID for the course-content-reader GitHub App |
 
 **Secrets (`secrets.*`):**
 
@@ -77,5 +77,5 @@ The following must be configured on the repository (or the `edx-berkeley` organi
 |---|---|
 | `GAR_SECRET_KEY_EDX` | GCP service account JSON key with push access to Google Artifact Registry |
 | `EDX_IMAGE_BUILDER_PRIVATE_KEY` | Private key for the GitHub App that opens PRs in edx-hub |
-| `OTTER_AUTOGRADERS_PRIVATE_KEY` | Private key for the GitHub App that reads autograder repos (shared with otter-service and xDevs) |
+| `COURSE_CONTENT_READER_PRIVATE_KEY` | Private key for the GitHub App that reads autograder/student/solution repos (shared with otter-service and xDevs) |
 | `SLACK_WEBHOOK_URL` | Incoming webhook URL for the `#edx-hub-ci` Slack channel |

--- a/README.md
+++ b/README.md
@@ -76,6 +76,6 @@ The following must be configured on the repository (or the `edx-berkeley` organi
 | Name | Description |
 |---|---|
 | `GAR_SECRET_KEY_EDX` | GCP service account JSON key with push access to Google Artifact Registry |
-| `PRIVATE_KEY_SECRET` | Private key for the GitHub App that opens PRs in edx-hub |
-| `OTTER_GH_APP_PRIVATE_KEY` | Private key for the GitHub App that reads autograder repos (shared with otter-service and xDevs) |
+| `EDX_IMAGE_BUILDER_PRIVATE_KEY` | Private key for the GitHub App that opens PRs in edx-hub |
+| `OTTER_AUTOGRADERS_PRIVATE_KEY` | Private key for the GitHub App that reads autograder repos (shared with otter-service and xDevs) |
 | `SLACK_WEBHOOK_URL` | Incoming webhook URL for the `#edx-hub-ci` Slack channel |


### PR DESCRIPTION
## Summary
- Rename `secrets.PRIVATE_KEY_SECRET` → `secrets.EDX_IMAGE_BUILDER_PRIVATE_KEY` in `build-push-create-pr.yaml`
- Rename `secrets.OTTER_GH_APP_PRIVATE_KEY` → `secrets.OTTER_AUTOGRADERS_PRIVATE_KEY` in `grader-check.yml`
- Update README secrets table to reflect new names

## Pre-merge requirement
Both new-named secrets must exist in repo settings before merging:
- `EDX_IMAGE_BUILDER_PRIVATE_KEY`
- `OTTER_AUTOGRADERS_PRIVATE_KEY`

Recommend rotating the keys at the same time (generate fresh .pem from each App's settings page).

## Test plan
- [ ] New-named secrets added to repo settings
- [ ] grader-check workflow runs green on this PR
- [ ] After merge: tag a release to verify build-push-create-pr.yaml works
- [ ] Old `PRIVATE_KEY_SECRET` and `OTTER_GH_APP_PRIVATE_KEY` deleted from repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)