### PR TITLE
ci: authenticate to Docker Hub in grader-check workflow

### DIFF
--- a/.github/workflows/grader-check.yml
+++ b/.github/workflows/grader-check.yml
@@ -23,6 +23,19 @@ jobs:
           sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc
           df -h
 
+      # Authenticate to Docker Hub before repo2docker runs. repo2docker pulls
+      # `docker.io/library/buildpack-deps:jammy` as its base image, and
+      # GitHub-hosted runners share NAT IPs across all of GitHub Actions —
+      # so anonymous pulls almost always hit Docker Hub's 100-pulls/6-hours
+      # per-IP rate limit. Authenticating attributes the pull to our service
+      # account instead of the shared IP pool. Account is the org-owned
+      # `edxberkeleyci` service identity (see CLAUDE.md / org settings).
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Build PR image
         uses: jupyterhub/repo2docker-action@master
         with:


### PR DESCRIPTION
## Summary

The Grader Check workflow has been failing on every PR with `toomanyrequests: You have reached your unauthenticated pull rate limit` when repo2docker tries to pull `docker.io/library/buildpack-deps:jammy`. GitHub-hosted runners share NAT IPs across the entire GitHub Actions fleet, so the per-IP 100-pulls/6-hour Docker Hub limit is exhausted basically constantly.

Adds a `docker/login-action@v3` step before repo2docker runs. Auth attributes pulls to our org's service account (`edxberkeleyci`) which has its own 200/6hr free-tier quota.

## Requires (already in place per Sean)

- Org variable: `DOCKERHUB_USERNAME` = service-account username
- Org secret: `DOCKERHUB_TOKEN` = read-only personal access token
- Both granted Repository access to `edx-user-image`

## Test plan

- [x] yamllint passes
- [ ] CI run on this PR pulls `buildpack-deps:jammy` successfully (no `toomanyrequests`)
- [ ] Grader Check itself completes end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)