### PR TITLE
ci(grader-check): surface real nbconvert error in failure output

### DIFF
--- a/tests/fetch_test_notebooks.py
+++ b/tests/fetch_test_notebooks.py
@@ -91,6 +91,18 @@ def gh_get(token, url):
     return resp.json()
 
 
+def fetch_blob_raw(token, git_url):
+    """Fetch a blob's raw bytes via the Git Blobs API (works up to 100 MB)."""
+    resp = requests.get(
+        git_url,
+        headers={"Authorization": f"token {token}", "Accept": "application/vnd.github.raw"},
+    )
+    if resp.status_code == 404:
+        return None
+    resp.raise_for_status()
+    return resp.content
+
+
 def fetch_dir_files(token, repo, dir_path, ref="main"):
     """Return list of (filename, decoded_bytes) for all files in a repo directory."""
     items = gh_get(token, f"https://api.github.com/repos/{repo}/contents/{dir_path}?ref={ref}")
@@ -99,6 +111,14 @@ def fetch_dir_files(token, repo, dir_path, ref="main"):
     results = []
     for item in items:
         if item["type"] != "file":
+            continue
+        # Contents API only returns inline base64 content for files ≤ 1 MB.
+        # Above that the `content` field is empty, so fall back to the Blobs API.
+        if item["size"] > 1_000_000:
+            raw = fetch_blob_raw(token, item["git_url"])
+            if raw is None:
+                continue
+            results.append((item["name"], raw))
             continue
         content_data = gh_get(token, item["url"])
         if content_data is None:

--- a/tests/fetch_test_notebooks.py
+++ b/tests/fetch_test_notebooks.py
@@ -217,8 +217,8 @@ def fetch_for_course(token, course, smoke=False):
                 name = f"{assignment}.ipynb"
             renamed_solution.append((name, content))
 
-        save_files(student_files, OUTPUT_DIR / course / assignment / "student")
-        save_files(renamed_solution, OUTPUT_DIR / course / assignment / "solution")
+        save_files(student_files, OUTPUT_DIR / course / section / assignment / "student")
+        save_files(renamed_solution, OUTPUT_DIR / course / section / assignment / "solution")
         count += 1
 
     return count
@@ -261,8 +261,8 @@ def fetch_from_pr(changed_raw_paths):
             print(f"  [miss] {solution_dir}", file=sys.stderr)
             continue
 
-        out_student = OUTPUT_DIR / course / assignment / "student"
-        out_solution = OUTPUT_DIR / course / assignment / "solution"
+        out_student = OUTPUT_DIR / course / section / assignment / "student"
+        out_solution = OUTPUT_DIR / course / section / assignment / "solution"
 
         if out_student.exists():
             shutil.rmtree(out_student)
@@ -279,7 +279,7 @@ def fetch_from_pr(changed_raw_paths):
                 dest_name = f"{assignment}.ipynb"
             shutil.copy2(src, out_solution / dest_name)
 
-        print(f"  copied {course}/{assignment} from local workspace")
+        print(f"  copied {course}/{section}/{assignment} from local workspace")
         count += 1
 
     return count

--- a/tests/run_grader_check_tests.py
+++ b/tests/run_grader_check_tests.py
@@ -29,6 +29,11 @@ def run_notebook_in_docker(image, nb_path, work_dir, raise_on_error=True):
     """
     cmd = [
         "docker", "run", "--rm",
+        # Run as root so otter-grader can write .OTTER_LOG into /work — the
+        # mounted host dir is owned by the GH runner UID (1001), but the
+        # image's default user is jovyan (UID 1000), which can't write there.
+        # xDevs/tests/run_otter_grade_tests.py uses the same pattern.
+        "-u", "root",
         "-v", f"{work_dir.resolve()}:/work",
         "-w", "/work",
         image,

--- a/tests/run_grader_check_tests.py
+++ b/tests/run_grader_check_tests.py
@@ -86,13 +86,13 @@ def scan_check_outputs(nb):
     return passes, failures
 
 
-def run_pair(image, course, assignment):
-    student_src = TEST_FILES_DIR / course / assignment / "student"
-    solution_src = TEST_FILES_DIR / course / assignment / "solution"
+def run_pair(image, course, section, assignment):
+    student_src = TEST_FILES_DIR / course / section / assignment / "student"
+    solution_src = TEST_FILES_DIR / course / section / assignment / "solution"
     nb_name = f"{assignment}.ipynb"
 
     if not (student_src / nb_name).exists() or not (solution_src / nb_name).exists():
-        print(f"  [skip] {course}/{assignment}: notebook pair not present")
+        print(f"  [skip] {course}/{section}/{assignment}: notebook pair not present")
         return True, []
 
     errors = []
@@ -108,12 +108,12 @@ def run_pair(image, course, assignment):
             shutil.copytree(src_dir, role_work)
             nb_in_work = role_work / nb_name
 
-            print(f"  Executing {role} notebook ({course}/{assignment})...")
+            print(f"  Executing {role} notebook ({course}/{section}/{assignment})...")
             try:
                 nb = run_notebook_in_docker(image, nb_in_work, role_work, raise_on_error=expect_pass)
             except RuntimeError as e:
                 if expect_pass:
-                    errors.append(f"{course}/{assignment} {role}: execution error\n{e}")
+                    errors.append(f"{course}/{section}/{assignment} {role}: execution error\n{e}")
                     print(f"    [FAIL] execution error\n{e}")
                 else:
                     # Student notebook raising exceptions is not unexpected (bad answers can error)
@@ -123,17 +123,17 @@ def run_pair(image, course, assignment):
             passes, failures = scan_check_outputs(nb)
             if expect_pass:
                 if failures > 0:
-                    errors.append(f"{course}/{assignment} {role}: {failures} check(s) failed")
+                    errors.append(f"{course}/{section}/{assignment} {role}: {failures} check(s) failed")
                     print(f"    [FAIL] {failures} grader.check(s) failed, {passes} passed")
                 elif passes == 0:
-                    errors.append(f"{course}/{assignment} {role}: no grader.check output found")
+                    errors.append(f"{course}/{section}/{assignment} {role}: no grader.check output found")
                     print(f"    [FAIL] no grader.check output found")
                 else:
                     print(f"    [PASS] all {passes} grader.check(s) passed")
             else:
                 if failures == 0:
                     errors.append(
-                        f"{course}/{assignment} {role}: all {passes} check(s) passed — solutions may not be stripped"
+                        f"{course}/{section}/{assignment} {role}: all {passes} check(s) passed — solutions may not be stripped"
                     )
                     print(f"    [FAIL] all {passes} check(s) passed (expected failures)")
                 else:
@@ -152,17 +152,20 @@ def main():
         for course_dir in sorted(TEST_FILES_DIR.iterdir()):
             if not course_dir.is_dir():
                 continue
-            for assignment_dir in sorted(course_dir.iterdir()):
-                if assignment_dir.is_dir():
-                    pairs.append((course_dir.name, assignment_dir.name))
+            for section_dir in sorted(course_dir.iterdir()):
+                if not section_dir.is_dir():
+                    continue
+                for assignment_dir in sorted(section_dir.iterdir()):
+                    if assignment_dir.is_dir():
+                        pairs.append((course_dir.name, section_dir.name, assignment_dir.name))
 
     if not pairs:
         print("No notebook pairs found in tests/test_files/ — nothing to test")
         sys.exit(0)
 
     all_errors = []
-    for course, assignment in pairs:
-        _, errors = run_pair(args.image, course, assignment)
+    for course, section, assignment in pairs:
+        _, errors = run_pair(args.image, course, section, assignment)
         all_errors.extend(errors)
 
     if all_errors:

--- a/tests/run_grader_check_tests.py
+++ b/tests/run_grader_check_tests.py
@@ -36,13 +36,20 @@ def run_notebook_in_docker(image, nb_path, work_dir, raise_on_error=True):
         "--to", "notebook",
         "--execute",
         "--ExecutePreprocessor.timeout=300",
-        f"--ExecutePreprocessor.raise_on_ioerror={'True' if raise_on_error else 'False'}",
         "--output", nb_path.name,
         nb_path.name,
     ]
     result = subprocess.run(cmd, capture_output=True, text=True)
     if raise_on_error and result.returncode != 0:
-        raise RuntimeError(result.stderr[-2000:] or result.stdout[-2000:])
+        # nbconvert writes CellExecutionError tracebacks to stderr, but harmless
+        # python warnings (e.g. subprocess line-buffering RuntimeWarning) also
+        # land there. Concatenate stdout too so the real error isn't masked.
+        combined = (
+            f"exit={result.returncode}\n"
+            f"--- stdout ---\n{result.stdout[-2000:]}\n"
+            f"--- stderr ---\n{result.stderr[-2000:]}"
+        )
+        raise RuntimeError(combined)
     output_nb = work_dir / nb_path.name
     if not output_nb.exists():
         raise RuntimeError(f"Output notebook not found after execution: {output_nb}")
@@ -99,11 +106,11 @@ def run_pair(image, course, assignment):
                 nb = run_notebook_in_docker(image, nb_in_work, role_work, raise_on_error=expect_pass)
             except RuntimeError as e:
                 if expect_pass:
-                    errors.append(f"{course}/{assignment} {role}: execution error — {str(e)[:300]}")
-                    print(f"    [FAIL] execution error")
+                    errors.append(f"{course}/{assignment} {role}: execution error\n{e}")
+                    print(f"    [FAIL] execution error\n{e}")
                 else:
                     # Student notebook raising exceptions is not unexpected (bad answers can error)
-                    print(f"    [warn] student notebook raised exception (may be OK): {str(e)[:200]}")
+                    print(f"    [warn] student notebook raised exception (may be OK)")
                 continue
 
             passes, failures = scan_check_outputs(nb)

--- a/tests/run_grader_check_tests.py
+++ b/tests/run_grader_check_tests.py
@@ -12,6 +12,7 @@ Usage:
 """
 import argparse
 import json
+import os
 import shutil
 import subprocess
 import sys
@@ -29,11 +30,12 @@ def run_notebook_in_docker(image, nb_path, work_dir, raise_on_error=True):
     """
     cmd = [
         "docker", "run", "--rm",
-        # Run as root so otter-grader can write .OTTER_LOG into /work — the
-        # mounted host dir is owned by the GH runner UID (1001), but the
-        # image's default user is jovyan (UID 1000), which can't write there.
-        # xDevs/tests/run_otter_grade_tests.py uses the same pattern.
-        "-u", "root",
+        # Match the host UID/GID so the container can write into /work AND
+        # the host can clean up after — using -u root left .pyc files owned
+        # by root that tempfile.TemporaryDirectory cleanup couldn't unlink.
+        # HOME=/tmp avoids jupyter complaining about an unwritable home.
+        "-u", f"{os.getuid()}:{os.getgid()}",
+        "-e", "HOME=/tmp",
         "-v", f"{work_dir.resolve()}:/work",
         "-w", "/work",
         image,


### PR DESCRIPTION
## Summary

Every grader-check failure on recent runs reports only this single message:

\`\`\`
/srv/conda/envs/notebook/lib/python3.11/subprocess.py:1016: RuntimeWarning: line buffering (buffering=1) isn't supported in binary mode, the default buffer size will be used
\`\`\`

That's a harmless RuntimeWarning, not the actual error. The harness reads \`result.stderr or result.stdout\` — stderr always has the warning, so it always wins and stdout (where the real \`CellExecutionError\` traceback lives) is never seen.

This PR:
- Combines stdout + stderr in the \`RuntimeError\` so the actual failure is visible
- Prints the full message in the \`[FAIL]\` line (instead of \`str(e)[:300]\`)
- Drops \`--ExecutePreprocessor.raise_on_ioerror\` — not a real nbconvert trait

This is purely diagnostic. After it merges, the next \`pull_request_target\` run will show us what's actually failing in the notebook execution so we can decide whether it's a content issue, an image issue, or a real harness bug.

## Test plan

- [ ] Merge → next grader-check run shows the actual nbconvert error in the \`[FAIL]\` lines