### PR TITLE
ci(yaml-lint): paths-ignore doc-only changes

### DIFF
--- a/.github/workflows/yaml-lint.yaml
+++ b/.github/workflows/yaml-lint.yaml
@@ -1,6 +1,12 @@
 name: Call Shared Yaml Lint Workflow
 on:
-  - pull_request  # yamllint disable-line rule:truthy
+  pull_request:
+    paths-ignore:
+      - "README.md"
+      - "CONTRIBUTING.md"
+      - "LICENSE"
+      - "docs/**"
+      - "images/**"
 
 jobs:
   call-shared-yaml-lint:


### PR DESCRIPTION
Matches the paths-ignore list already used by build-test-image.yaml and grader-check.yml in this repo. Stops yaml-lint from running on pure README/CONTRIBUTING/LICENSE/docs PRs.