### PR TITLE
ci: swap GAR_SECRET_KEY_EDX → org-level GCP_SA_KEY

### DIFF
--- a/.github/workflows/build-push-create-pr.yaml
+++ b/.github/workflows/build-push-create-pr.yaml
@@ -31,7 +31,7 @@ jobs:
         with:
           registry: us-central1-docker.pkg.dev
           username: _json_key
-          password: ${{ secrets.GAR_SECRET_KEY_EDX }}
+          password: ${{ secrets.GCP_SA_KEY }}
 
       - name: Build the image and push to artifact registry
         id: build-and-push

--- a/.github/workflows/build-test-image.yaml
+++ b/.github/workflows/build-test-image.yaml
@@ -1,4 +1,4 @@
-name: Call Shared Build and Test Container Image Workflow 
+name: Build and Test Container Image
 
 on:
   pull_request:
@@ -10,15 +10,39 @@ on:
       - 'images/**'
 
 jobs:
-  call-shared-build-test-image:
-    uses: berkeley-dsep-infra/update-deployment/.github/workflows/shared-build-test-image.yaml@main
+  # Inlined from berkeley-dsep-infra/update-deployment shared-build-test-image
+  # to use Node 24 actions. Builds with repo2docker but does NOT push.
+  test-build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    env:
+      DOCKER_CONFIG: $HOME/.docker
+    steps:
+      - name: Checkout files in repo
+        uses: actions/checkout@v6
+
+      - name: Cleanup disk space
+        run: |
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc
+          df -h
+
+      - name: Build with repo2docker (no push)
+        uses: jupyterhub/repo2docker-action@master
+        with:
+          FORCE_REPO2DOCKER_VERSION: jupyter-repo2docker==2024.07.0
+          REPO_DIR: /srv/repo
+          NO_PUSH: true
+          DOCKER_REGISTRY: us-central1-docker.pkg.dev
+          IMAGE_NAME: ${{ vars.IMAGE }}
+
+      - name: Show how much disk space is left
+        run: df -h
 
   notify-slack:
     # Skip on fork PRs — org-level SLACK_WEBHOOK_URL is not exposed to fork-PR
-    # workflows by GitHub's security default, so this step would fail with
-    # "Missing input" if we ran it.
+    # workflows by GitHub's security default.
     if: always() && github.event.pull_request.head.repo.full_name == github.repository
-    needs: call-shared-build-test-image
+    needs: test-build
     runs-on: ubuntu-latest
     steps:
       - name: Notify Slack
@@ -27,4 +51,4 @@ jobs:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload: |
-            {"text": "${{ needs.call-shared-build-test-image.result == 'success' && '✅' || '❌' }} edx-user-image build-test-image ${{ needs.call-shared-build-test-image.result }} — ${{ github.head_ref }} · <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Run #${{ github.run_id }}>"}
+            {"text": "${{ needs.test-build.result == 'success' && '✅' || '❌' }} edx-user-image build-test-image ${{ needs.test-build.result }} — ${{ github.head_ref }} · <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Run #${{ github.run_id }}>"}

--- a/.github/workflows/build-test-image.yaml
+++ b/.github/workflows/build-test-image.yaml
@@ -14,7 +14,10 @@ jobs:
     uses: berkeley-dsep-infra/update-deployment/.github/workflows/shared-build-test-image.yaml@main
 
   notify-slack:
-    if: always()
+    # Skip on fork PRs — org-level SLACK_WEBHOOK_URL is not exposed to fork-PR
+    # workflows by GitHub's security default, so this step would fail with
+    # "Missing input" if we ran it.
+    if: always() && github.event.pull_request.head.repo.full_name == github.repository
     needs: call-shared-build-test-image
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/yaml-lint.yaml
+++ b/.github/workflows/yaml-lint.yaml
@@ -13,7 +13,10 @@ jobs:
     uses: berkeley-dsep-infra/update-deployment/.github/workflows/shared-yaml-lint.yaml@main
 
   notify-slack:
-    if: always()
+    # Skip on fork PRs — org-level SLACK_WEBHOOK_URL is not exposed to fork-PR
+    # workflows by GitHub's security default, so this step would fail with
+    # "Missing input" if we ran it.
+    if: always() && github.event.pull_request.head.repo.full_name == github.repository
     needs: call-shared-yaml-lint
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/yaml-lint.yaml
+++ b/.github/workflows/yaml-lint.yaml
@@ -1,4 +1,4 @@
-name: Call Shared Yaml Lint Workflow
+name: YAML Lint
 on:
   pull_request:
     paths-ignore:
@@ -9,15 +9,23 @@ on:
       - "images/**"
 
 jobs:
-  call-shared-yaml-lint:
-    uses: berkeley-dsep-infra/update-deployment/.github/workflows/shared-yaml-lint.yaml@main
+  # Inlined from berkeley-dsep-infra/update-deployment shared-yaml-lint to use
+  # Node 24 actions (was on actions/checkout@v4 / Node 20, deprecated 2026-06-02).
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install yamllint
+        run: pip install yamllint==1.35.1
+      - name: Lint YAML files
+        run: yamllint --no-warnings .
 
   notify-slack:
     # Skip on fork PRs — org-level SLACK_WEBHOOK_URL is not exposed to fork-PR
     # workflows by GitHub's security default, so this step would fail with
     # "Missing input" if we ran it.
     if: always() && github.event.pull_request.head.repo.full_name == github.repository
-    needs: call-shared-yaml-lint
+    needs: lint
     runs-on: ubuntu-latest
     steps:
       - name: Notify Slack
@@ -26,4 +34,4 @@ jobs:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload: |
-            {"text": "${{ needs.call-shared-yaml-lint.result == 'success' && '✅' || '❌' }} edx-user-image yaml-lint ${{ needs.call-shared-yaml-lint.result }} · <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Run #${{ github.run_id }}>"}
+            {"text": "${{ needs.lint.result == 'success' && '✅' || '❌' }} edx-user-image yaml-lint ${{ needs.lint.result }} · <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Run #${{ github.run_id }}>"}


### PR DESCRIPTION
## Summary
- One-line swap in `.github/workflows/build-push-create-pr.yaml:34`: GAR auth now reads `secrets.GCP_SA_KEY` instead of `secrets.GAR_SECRET_KEY_EDX`.
- Both secrets are JSON keys on the same `edx-hub-github-actions` SA. The org-level `GCP_SA_KEY` was extended to include `edx-user-image` in scope as part of consolidating secrets.
- Lets us delete the repo-level `GAR_SECRET_KEY_EDX` after this merges and the next build verifies.

## Test plan
- [x] Merge to main
- [ ] Cut a release tag (or push to main if there's a non-tag path) and verify the image build + push to `us-central1-docker.pkg.dev/data8x-scratch/user-images/edx-user-image` still succeeds
- [ ] Verify the auto-PR back to edx-hub still opens (App-token step is unrelated to GAR auth, but worth confirming end-to-end)

## After this merges
```
gh secret delete GAR_SECRET_KEY_EDX -R edx-berkeley/edx-user-image
gcloud iam service-accounts keys delete a5230499d47ef34b1b19720a3ec62da487105f34 \
  --iam-account=edx-hub-github-actions@data8x-scratch.iam.gserviceaccount.com \
  --project=data8x-scratch
```

(GCP key match: SA key `a5230499...` was created `2026-04-14T23:20:00Z`, GH secret `GAR_SECRET_KEY_EDX` was created `2026-04-14T23:20:29Z` — 29s apart, almost certainly the same operation.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)