### PR TITLE
chore: refresh stale Docker Hub account reference in grader-check comment

### DIFF
--- a/.github/workflows/grader-check.yml
+++ b/.github/workflows/grader-check.yml
@@ -28,8 +28,13 @@ jobs:
       # GitHub-hosted runners share NAT IPs across all of GitHub Actions —
       # so anonymous pulls almost always hit Docker Hub's 100-pulls/6-hours
       # per-IP rate limit. Authenticating attributes the pull to our service
-      # account instead of the shared IP pool. Account is the org-owned
-      # `edxberkeleyci` service identity (see CLAUDE.md / org settings).
+      # account instead of the shared IP pool. Account: Berkeley SPA
+      # `edxcdss` tied to edx-ds@berkeley.edu (org var DOCKERHUB_USERNAME +
+      # org secret DOCKERHUB_TOKEN, SELECTED scope: this repo, edx-hub,
+      # otter-service). When rotating, always pass --visibility selected
+      # --repos ... to gh secret/variable set — defaulting to PRIVATE
+      # breaks this PUBLIC repo's access. SPA password SOPS-encrypted at
+      # edx-hub/deployments/edx/secrets/service-accounts.yaml.
       - name: Log in to Docker Hub
         uses: docker/login-action@v4
         with:


### PR DESCRIPTION
## Summary

Updates the inline comment in [grader-check.yml#L26-32](.github/workflows/grader-check.yml#L26-L32) which said the Docker Hub identity was the org-owned `edxberkeleyci` account. That was already drifted (the actual value was Sean's personal `seansmorris`) and as of 2026-06-09 has been rotated to the Berkeley SPA `edxcdss` tied to `edx-ds@berkeley.edu`.

## Comment-only change

No workflow behavior changes. The new comment block records:
- Which Berkeley SPA backs the Docker Hub identity (`edxcdss` / `edx-ds@berkeley.edu`)
- Which GH org var + secret hold the username + PAT
- The **SELECTED-scope footgun** we hit + debugged tonight: `gh secret set` / `gh variable set` without `--visibility selected --repos ...` drops to PRIVATE, which silently breaks this PUBLIC repo's access. Failure mode is `Username and password required`. Required two re-sets to get back to working.
- Where the SPA password lives (SOPS-encrypted at `edx-hub/deployments/edx/secrets/service-accounts.yaml`)

## Background

See [edx_service_account memory note](https://github.com/sean-morris/claude-memory-edx-berkeley/blob/main/edx_service_account.md) for the full story — the same SPA email now backs two CI/cred chains (edX.org login + Docker Hub).

🤖 Generated with [Claude Code](https://claude.com/claude-code)